### PR TITLE
misspelling fix from deposite- to deposit-

### DIFF
--- a/contracts/nft-bridge/INFTBridgeMainchain.sol
+++ b/contracts/nft-bridge/INFTBridgeMainchain.sol
@@ -6,7 +6,7 @@ interface INFTBridgeMainchain {
      * Events *
      **********/
 
-    event DepositeInitiated(
+    event DepositInitiated(
         uint256 indexed depositIndex,
         address indexed mainchainERC721,
         uint256 indexed tokenId,
@@ -15,7 +15,7 @@ interface INFTBridgeMainchain {
         address sideTo
     );
 
-    event DepositeRejected(uint256 indexed depositIndex);
+    event DepositRejected(uint256 indexed depositIndex);
 
     event WithdrawalFinalized(
         uint256 indexed depositIndex,

--- a/contracts/nft-bridge/INFTBridgeSidechain.sol
+++ b/contracts/nft-bridge/INFTBridgeSidechain.sol
@@ -14,7 +14,7 @@ interface INFTBridgeSidechain {
         string symbol
     );
 
-    event DepositeFinalized(
+    event DepositFinalized(
         uint256 indexed mainchainId,
         uint256 indexed depositIndex,
         address mainchainERC721,
@@ -24,7 +24,7 @@ interface INFTBridgeSidechain {
         address sideTo
     );
 
-    event DepositeFailed(
+    event DepositFailed(
         uint256 indexed mainchainId,
         uint256 indexed depositIndex,
         address mainchainERC721,

--- a/contracts/nft-bridge/NFTBridgeMainchain.sol
+++ b/contracts/nft-bridge/NFTBridgeMainchain.sol
@@ -50,7 +50,7 @@ contract NFTBridgeMainchain is INFTBridgeMainchain, Ownable {
             DepositInfo(mainchainERC721, tokenId, msg.sender, address(0))
         );
 
-        emit DepositeInitiated(
+        emit DepositInitiated(
             depositInfos.length - 1,
             mainchainERC721,
             tokenId,
@@ -81,7 +81,7 @@ contract NFTBridgeMainchain is INFTBridgeMainchain, Ownable {
             mainInfo.tokenId
         );
 
-        emit DepositeRejected(depositIndex);
+        emit DepositRejected(depositIndex);
     }
 
     /**

--- a/contracts/nft-bridge/NFTBridgeSidechain.sol
+++ b/contracts/nft-bridge/NFTBridgeSidechain.sol
@@ -110,7 +110,7 @@ contract NFTBridgeSidechain is INFTBridgeSidechain, Ownable {
             mainchainERC721
         );
         if (sidechainERC721 == address(0)) {
-            emit DepositeFailed(
+            emit DepositFailed(
                 mainchainId,
                 depositIndex,
                 mainchainERC721,
@@ -130,7 +130,7 @@ contract NFTBridgeSidechain is INFTBridgeSidechain, Ownable {
         depositIndexMap[sidechainERC721][tokenId] = depositIndex;
 
         try SidechainERC721(sidechainERC721).mint(sideTo, tokenId) {
-            emit DepositeFinalized(
+            emit DepositFinalized(
                 mainchainId,
                 depositIndex,
                 mainchainERC721,
@@ -140,7 +140,7 @@ contract NFTBridgeSidechain is INFTBridgeSidechain, Ownable {
                 sideTo
             );
         } catch {
-            emit DepositeFailed(
+            emit DepositFailed(
                 mainchainId,
                 depositIndex,
                 mainchainERC721,


### PR DESCRIPTION
I'm dev lead of Catze Labs, who operates YOOLDO, TroublePunk and CyberGalz.

Just studying OASYS structure by checking all the contract source code and found misspelling.

Dictionary said 'deposite' is obsolete spelling of deposit.

Actually this is very small mistake but wanna contribute for perfect launch of oasys :)